### PR TITLE
Reorganize nav links.

### DIFF
--- a/csgc-jekyll-src/_config.yml
+++ b/csgc-jekyll-src/_config.yml
@@ -19,6 +19,17 @@ description: >- # this means to ignore newlines until "baseurl:"
   Computer Science Graduate Council at Virginia Tech
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://csgrad.cs.vt.edu" # the base hostname & protocol for your site, e.g. http://example.com
+main_pages:
+  - url: "/constitution_minutes/"
+    title: "Constitution and Minutes"
+  - url: "/events/"
+    title: "Events"
+  - url: "/links/"
+    title: "Links"
+  - url: "/ReadingGroups/"
+    title: "Reading Groups"
+  - url: "/travel_funding/"
+    title: "Travel Funding"
 twitter_username: 
 github_username:  
 

--- a/csgc-jekyll-src/_includes/sidebar.html
+++ b/csgc-jekyll-src/_includes/sidebar.html
@@ -10,22 +10,18 @@
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ "/" | relative_url }}">Home</a>
-
       {% comment %}
         The code below dynamically generates a sidebar nav of pages with
         `layout: page` in the front-matter. See readme for usage.
       {% endcomment %}
 
-      {% assign pages_list = site.pages %}
+      {% assign pages_list = site.main_pages %}
       {% for node in pages_list %}
         {% if node.title != null and node.title != "About CS Grad Council" %}
-          {% if node.layout == "page" %}
-            <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
-          {% endif %}
+          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
         {% endif %}
       {% endfor %}
-
+      
       <span class="sidebar-nav-item">Last updated {{ site.time | date: '%m-%d-%y' }}
 </span>
     </nav>

--- a/csgc-jekyll-src/constitution-minutes.md
+++ b/csgc-jekyll-src/constitution-minutes.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Constitution and Minutes
+permalink: /constitution_minutes/
+---
+
+The Grad Council abides by this [constitution](https://docs.google.com/a/vt.edu/document/d/1YrcqQCxML7jFIrtPRbh80wkqDbkA-7syDoGd6AdtGpQ/edit?usp=sharing), approved by the acting graduate council on October 19, 2017.
+
+If you're interested in what happens at Grad Council meetings, you've come to the right place.
+Meeting minutes live in this Google Drive [folder](https://drive.google.com/open?id=0B18IykdpRSYPVE9tQUExLUd3c2s) and can be viewed by anyone with a VT email address.

--- a/csgc-jekyll-src/constitution.md
+++ b/csgc-jekyll-src/constitution.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: Constitution
-permalink: /constitution/
----
-
-The Grad Council abides by this [constitution](https://docs.google.com/a/vt.edu/document/d/1YrcqQCxML7jFIrtPRbh80wkqDbkA-7syDoGd6AdtGpQ/edit?usp=sharing), approved by the acting graduate council on October 19, 2017.

--- a/csgc-jekyll-src/links.md
+++ b/csgc-jekyll-src/links.md
@@ -4,6 +4,7 @@ title: Links
 permalink: /links/
 ---
 
-
 * [Nomination form for CS Grad Council positions](https://goo.gl/forms/RrUwcIDPgUFHJak82).
 * [Survey for requesting travel funds](https://virginiatech.qualtrics.com/SE/?SID=SV_dgLcRAZnEDAnH2l)
+* [Grad Council officers](/Officers/)
+* [Information about organizing events](/events/organizing-an-event)

--- a/csgc-jekyll-src/minutes.md
+++ b/csgc-jekyll-src/minutes.md
@@ -1,9 +1,0 @@
----
-layout: page
-title: Minutes
-permalink: /minutes/
----
-
-If you're interested in what happens at Grad Council meetings, you've come to the right place.
-
-Meeting minutes live in this Google Drive [folder](https://drive.google.com/open?id=0B18IykdpRSYPVE9tQUExLUd3c2s) and can be viewed by anyone with a VT email address.


### PR DESCRIPTION
Sidebar only includes links to "main pages". Links to other pages were either added to the `Links` page and/or to other pages if appropriate. Sidebar looks less full now, but (in my opinion) contains only useful links.

When adding a new page, if you want it to be in the sidebar, add the page to _config.yml with `title` and `/url/` fields and you're good to go. Otherwise, add a link to it from another page that you think would make sense.