### PR TITLE
Making sidebar nav more pretty

### DIFF
--- a/csgc-jekyll-src/assets/css/hyde.css
+++ b/csgc-jekyll-src/assets/css/hyde.css
@@ -66,6 +66,7 @@ html {
     left: 0;
     width: 18rem;
     text-align: left;
+    min-height: 100%;
   }
 }
 


### PR DESCRIPTION
The sidebar was changed a few commits ago. Now it doesn't always extend to the bottom of  the screen, and I think it looks better when it goes all the way.

**Before**

<kbd>
<img width="1280" style="border:10px solid black;" alt="image" src="https://user-images.githubusercontent.com/7769932/63960495-9f4df880-ca5c-11e9-8c78-a83b0ca8aeb3.png">
</kbd>


**After**

<kbd>
<img width="1280" style="border:10px solid black;" alt="image" src="https://user-images.githubusercontent.com/7769932/63960526-b1c83200-ca5c-11e9-9374-ec3e81adeaa0.png">
</kbd>