### PR TITLE
Update events section by removing past events details

### DIFF
--- a/events.md
+++ b/events.md
@@ -8,21 +8,11 @@ The CS Grad Council Google Calender can be found [here](https://calendar.google.
 
 ## <a name="UpcomingEvents"></a>Upcoming Events<a href="#UpcomingEvents"><i class="fa fa-link" aria-hidden="true"></i></a>
 
-#### Industry-Academia Jobs Panel
-- *What*: Come here a panel discussion from recent VT alums and professors in industry and academia! [RSVP here](https://forms.gle/kxnAfp3CUUb3YFkg8).
-- *When*: 5:30pm-6:30pm ET, Tuesday, November 14th, 2023
-- *Where*: GLC Room F (or on Zoom; link on RSVP form)
-
 #### Biweekly Meetings
 - *What*: The CS Grad Council's biweekly meeting -- all CS grad students are welcome!
-- *When*: Alternating Mondays at 12:30pm (Oct 9, Oct 23, Nov 6, Nov 27)
-- *Where*: Gilbert room 3001 (or on Zoom; check email for link!)
+- *When*: Alternating Thursdays at 11:00am (Feb 12, Feb 26, Mar 12, Mar 26, Apr 9, Apr 23, May 7)
+- *Where*: Gilbert room 3002 (or on Zoom; check email for link!)
 
 ## <a name="PastEvents"></a>Past Events<a href="#PastEvents"><i class="fa fa-link" aria-hidden="true"></i></a>
-
-#### Lightning Talks
-- *What*: Come hear 3-minute lightning talks on research and other topics of interest!
-- *When*: 6:00pm EST, Thursday, October 12th, 2023
-- *Where*: GLC Room F (or on Zoom; link on RSVP form)
 
 More past events can be found [here](https://csgrad.cs.vt.edu/events/past-events/).

--- a/meetings.md
+++ b/meetings.md
@@ -5,16 +5,17 @@ permalink: /meetings/
 ---
 
 ## <a name="Regularmeetings"></a>Regular meetings<a href="#Regularmeetings"><i class="fa fa-link" aria-hidden="true"></i></a>
-Time: Every other Monday, 12:30 to 1:30 (Fall 2023)
-* ~~Aug 28~~
-* ~~Sep 11~~
-* ~~Sep 25~~
-* ~~Oct 09~~
-* ~~Oct 23~~
-* ~~Nov 06~~
-* Nov 27
+Time: Every other Thursday, 11:00 am to 12:00 pm (Spring 2026)
+* ~~Jan 29~~
+* Feb 12
+* Feb 26
+* Mar 12
+* Mar 26
+* Apr 9
+* Apr 23
+* May 7
 
-Location: Gilbert 3001 and Zoom. Please access the link from the [Calendar Event](https://calendar.google.com/calendar?cid=dnQuZWR1X240bnQ0aGdlNTBrdjdqajFjZDN1NzllaW1rQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+Location: Gilbert 3002 and Zoom. Please access the link from the [Calendar Event](https://calendar.google.com/calendar?cid=dnQuZWR1X240bnQ0aGdlNTBrdjdqajFjZDN1NzllaW1rQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
 
 ## <a name="Contact"></a>Contact<a href="#Contact"><i class="fa fa-link" aria-hidden="true"></i></a>
 * See the [mailing list](https://groups.google.com/a/vt.edu/forum/#!forum/csgc-g) to see what we're up to or to get in touch.


### PR DESCRIPTION
- Removed details for the Industry-Academia Jobs Panel and Lightning Talks events. 
- Updated the schedule for Biweekly Meetings.